### PR TITLE
ゲームオーバー関連の不具合の修正

### DIFF
--- a/GameTemplate/Game/GameOver.cpp
+++ b/GameTemplate/Game/GameOver.cpp
@@ -4,6 +4,7 @@
 #include "Fade.h"
 #include "Title.h"
 #include "Game.h"
+#include "Scene.h"
 
 //デストラクタ。
 GameOver::~GameOver()
@@ -251,6 +252,23 @@ void GameOver::Action()
 			if (g_gameTime->StopWatch(3.0f))
 			{
 				DeleteGO(this);
+
+				//現在ステージ1をプレイしているとき
+				if (m_game->GetStageState() == m_game->enStageState_Stage1)
+				{
+					//ステージ1オブジェクトの削除
+					m_game->Stage1ObjectDelete();
+				}
+				//現在ステージ2をプレイしているとき
+				else if (m_game->GetStageState() == m_game->enStageState_Stage2)
+				{
+					//ステージ2オブジェクトの削除
+					m_game->Stage2ObjectDelete();
+				}
+
+				//メインオブジェクトの削除
+				m_game->MainObjectDelete();
+
 				DeleteGO(m_game);
 				NewGO<Game>(0, "game");
 			}
@@ -260,8 +278,26 @@ void GameOver::Action()
 			if (g_gameTime->StopWatch(2.0f))
 			{
 				DeleteGO(this);
+				
+				//現在ステージ1をプレイしているとき
+				if (m_game->GetStageState() == m_game->enStageState_Stage1)
+				{
+					//ステージ1オブジェクトの削除
+					m_game->Stage1ObjectDelete();
+				}
+				//現在ステージ2をプレイしているとき
+				else if (m_game->GetStageState() == m_game->enStageState_Stage2)
+				{
+					//ステージ2オブジェクトの削除
+					m_game->Stage2ObjectDelete();
+				}
+
+				//メインオブジェクトの削除
+				m_game->MainObjectDelete();
+
 				DeleteGO(m_game);
-				NewGO<Title>(0, "title");
+				//SceneManagerを経由してタイトル画面への遷移を要求する
+				Scene_Manager::GetInstance()->SetRequest(SceneID::S_Title);
 			}
 			break;
 		default:

--- a/GameTemplate/Game/Scene.cpp
+++ b/GameTemplate/Game/Scene.cpp
@@ -7,6 +7,7 @@
 #include "StageClear.h"
 #include "Player.h"
 #include "GameClear.h"
+#include "GameOver.h"
 #define SMGetIns Scene_Manager::GetInstance // シングルトンインスタンスを取得するマクロ定義
 
 Scene_Manager* Scene_Manager::instance = nullptr; // シングルトンインスタンスの初期化
@@ -90,6 +91,13 @@ void Stage1Scene::Update()
 			SMGetIns()->SetRequest(SceneID::S_Stage2);
 		}
 	}
+
+	//SceneManagerを経由してタイトル画面への遷移を要求していたら
+	if (Scene_Manager::GetInstance()->GetRequest() == SceneID::S_Title)
+	{
+		//タイトル画面に遷移する
+		SMGetIns()->SetRequest(SceneID::S_Title);
+	}
 }
 
 // ステージ2シーン::初期化処理。
@@ -133,6 +141,13 @@ void Stage2Scene::Update()
 	{
 		// ステージクリアフラグが立っている場合、ステージ2へ遷移する。  
 		SMGetIns()->SetRequest(SceneID::S_GameClear);
+	}
+
+	//SceneManagerを経由してタイトル画面への遷移を要求していたら
+	if (Scene_Manager::GetInstance()->GetRequest() == SceneID::S_Title)
+	{
+		//タイトル画面に遷移する
+		SMGetIns()->SetRequest(SceneID::S_Title);
 	}
 }
 


### PR DESCRIPTION
・選択が終わった後にLoadingが入ってオブジェクトをDeleteGOするはずができていない不具合をしました。

・タイトルへ戻るを選択してタイトル画面に戻った後に再度ゲームスタートを選択したらGameクラスがNewGOしない不具合をしました。