### PR TITLE
当たり判定の不具合の修正

### DIFF
--- a/GameTemplate/Game/RotationFloor.cpp
+++ b/GameTemplate/Game/RotationFloor.cpp
@@ -59,7 +59,12 @@ void RotationFloor::Update()
 	Rotation();
 
 	// 当たり判定。
-	m_physicsStaticObject.SetPosition(m_position);
+	m_physicsStaticObject.Release();
+	m_physicsStaticObject.CreateFromModel
+	(
+		m_modelRender.GetModel(),
+		m_modelRender.GetModel().GetWorldMatrix()
+	);
 
 	// コリジョン。
 	m_collisionObject->SetPosition(m_position + COLLISION_HEIGHT);

--- a/GameTemplate/Game/RotationFloor.cpp
+++ b/GameTemplate/Game/RotationFloor.cpp
@@ -6,8 +6,8 @@
 namespace
 {
 	const Vector3 SCALE{ 5.0f, 5.0f, 5.0f };// モデルの大きさ。
-	const Vector3 COLLISION_HEIGHT(0.0f, 250.0f, 0.0f);// コリジョンの高さ。
-	const Vector3 COLLISION_SIZE(500.0f, 3.0f, 225.0f);// コリジョンの大きさ。
+	const Vector3 COLLISION_HEIGHT(0.0f, 140.0f, 0.0f);// コリジョンの高さ。
+	const Vector3 COLLISION_SIZE(190.0f, 280.0f, 290.0f);// コリジョンの大きさ。
 
 }
 
@@ -68,7 +68,29 @@ void RotationFloor::Update()
 
 	// コリジョン。
 	m_collisionObject->SetPosition(m_position + COLLISION_HEIGHT);
+	m_collisionObject->SetRotation(m_Rot);
 
+	//距離を求める
+	m_distance = m_position - m_player->m_position;
+
+	//プレイヤーがジャンプしているとき
+	if (!m_player->m_characterController.IsOnGround())
+	{
+		//回転床のコリジョンに衝突したら
+		if (m_collisionObject->IsHit(m_player->m_characterController)) {
+			//X方向にプレイヤーを移動する
+			Vector3 playerPos = m_player->GetPosition();
+			if (playerPos.x < m_position.x) {
+				playerPos.x -= 22.0f;
+			}
+			else {
+				playerPos.x += 22.0f;
+			}
+			m_player->m_characterController.SetPosition(playerPos);
+			m_player->m_modelRender.SetPosition(playerPos);
+			m_player->m_modelRender.Update();
+		}
+	}
 
 	//m_modelRender.SetPosition(m_position);
 	m_modelRender.SetRotation(m_Rot);

--- a/GameTemplate/Game/RotationFloor.h
+++ b/GameTemplate/Game/RotationFloor.h
@@ -30,6 +30,7 @@ public:
 	CollisionObject* m_collisionObject;
 	Player* m_player = nullptr;
 	Vector3 m_position;
+	Vector3 m_distance;//距離
 	ModelRender m_modelRender;
 	PhysicsStaticObject m_physicsStaticObject;
 	Quaternion m_Rot;

--- a/GameTemplate/Game/Tower.cpp
+++ b/GameTemplate/Game/Tower.cpp
@@ -20,7 +20,7 @@ bool Tower::Start()
 	m_modelRender.Init("Assets/modelData/Tower/Tower.tkm", 0, 0, enModelUpAxisZ, false, true);
 
 	m_modelRender.SetScale(SCALE);
-//	m_modelRender.Update();
+	m_modelRender.Update();
 	//当たり判定
 	m_physicsStaticObject.CreateFromModel(m_modelRender.GetModel(), m_modelRender.GetModel().GetWorldMatrix());
 

--- a/GameTemplate/Game/Tower.cpp
+++ b/GameTemplate/Game/Tower.cpp
@@ -9,8 +9,8 @@ namespace
 	const float SPEED = 500.0f; // 移動速度。
 
 	const Vector3 SCALE(1.5f, 3.0f, 3.0f);
-	const Vector3 COLLISION_HEIGHT(0.0f, 50.0f, 0.0f);// コリジョンの高さ。
-	const Vector3 COLLISION_SIZE(365.0f, 5.0f, 225.0f);// コリジョンの大きさ。
+	const Vector3 COLLISION_HEIGHT(0.0f, 600.0f, 0.0f);// コリジョンの高さ。
+	const Vector3 COLLISION_SIZE(60.0f, 5.0f, 60.0f);// コリジョンの大きさ。
 
 }
 
@@ -106,9 +106,52 @@ void Tower::Move()
 	}
 	m_modelRender.Update();
 	m_modelRender.SetPosition(m_position);
+
+	//プレイヤーがジャンプしているとき
+	if (!m_player->m_characterController.IsOnGround())
+	{
+		//プレイヤーがタワーでジャンプしたら処理しない。
+		if (m_playerTowerJumpFlag)
+		{
+			return;
+		}
+
+		//タワーのコリジョンの衝突判定
+		TowerCollisionDetection();
+
+		//タワーのコリジョンに衝突していたら
+		if (!m_isNotHitTowerCollision)
+		{
+			//慣性を考慮したジャンプをする。
+			m_player->m_moveSpeed.y += moveSpeed.y;
+			m_playerTowerJumpFlag = true;
+		}
+	}
+	//プレイヤーがジャンプしていないとき
+	else
+	{
+		//地面に着地したらフラグをリセット
+		m_isHitTowerCollision = false;
+		m_isNotHitTowerCollision = false;
+		m_playerTowerJumpFlag = false;
+	}
 }
 
 void Tower::Render(RenderContext& rc)
 {
 	m_modelRender.Draw(rc);
+}
+
+void Tower::TowerCollisionDetection()
+{
+	//タワーのコリジョンに衝突したら
+	if (m_collisionObject->IsHit(m_player->m_characterController))
+	{
+		m_isHitTowerCollision = true;
+	}
+	//タワー以外のコリジョンに衝突したら
+	else
+	{
+		m_isNotHitTowerCollision = true;
+	}
 }

--- a/GameTemplate/Game/Tower.h
+++ b/GameTemplate/Game/Tower.h
@@ -26,6 +26,11 @@ public:
 		return m_position;
 	}
 
+	/// <summary>
+	/// タワーのコリジョンの衝突判定
+	/// </summary>
+	void TowerCollisionDetection();
+
 	Vector3 m_position;
 	Vector3 m_firstPosition;
 
@@ -35,6 +40,10 @@ private:
 	Player* m_player = nullptr;
 	PhysicsStaticObject m_physicsStaticObject;
 	ModelRender m_modelRender;
+
+	bool m_isHitTowerCollision = false;//タワーのコリジョンに衝突したか？
+	bool m_isNotHitTowerCollision = false;//タワーのコリジョンに衝突していないか?
+	bool m_playerTowerJumpFlag = false;//プレイヤーがタワーでジャンプしたか？
 
 	// 移動方向を決めるステート。
 	enum enMovingFloorState


### PR DESCRIPTION
・回転床とタワーの当たり判定を貫通する不具合の修正をしました。

・回転床で特定の位置にいたら貫通する不具合の修正をしました。

・タワーでジャンプしたら慣性を考慮したジャンプをしない不具合の修正をしました。