### PR TITLE
インゲームでの不具合の修正と調整

### DIFF
--- a/GameTemplate/Game/Block.cpp
+++ b/GameTemplate/Game/Block.cpp
@@ -9,6 +9,10 @@ namespace
   const	Vector3 COLLISION_SIZE(100.0f, 100.0f, 25.0f);
 }
 
+Block::~Block()
+{
+	DeleteGO(m_collisionObject);
+}
 
 // 初期化処理。
 bool Block::Start()

--- a/GameTemplate/Game/Block.h
+++ b/GameTemplate/Game/Block.h
@@ -7,7 +7,7 @@ class Block : public IGameObject
 {
 public:
 	Block() {};
-	~Block() {};
+	~Block();
 
 	bool Start();// 初期化処理。
 	void Update();// 更新処理。

--- a/GameTemplate/Game/FallingBlock.cpp
+++ b/GameTemplate/Game/FallingBlock.cpp
@@ -16,6 +16,11 @@ namespace
 
 }
 
+FallingBlock::~FallingBlock()
+{
+	DeleteGO(m_collisionObject);
+}
+
 // 初期化処理。
 bool FallingBlock::Start()
 {

--- a/GameTemplate/Game/FallingBlock.h
+++ b/GameTemplate/Game/FallingBlock.h
@@ -13,7 +13,7 @@ class FallingBlock : public IGameObject
 	/// </summary>
 public:
 	FallingBlock() {};
-	~FallingBlock() {};
+	~FallingBlock();
 
 	bool Start();
 	void Update();

--- a/GameTemplate/Game/FallingFloor.cpp
+++ b/GameTemplate/Game/FallingFloor.cpp
@@ -15,6 +15,11 @@ namespace
 
 }
 
+FallingFloor::~FallingFloor()
+{
+	DeleteGO(m_collisionObject);
+}
+
 // 初期化処理。
 bool FallingFloor::Start()
 {

--- a/GameTemplate/Game/FallingFloor.h
+++ b/GameTemplate/Game/FallingFloor.h
@@ -9,7 +9,7 @@ public:
 	/// 第2ステージ専用モデル 兼 LevelObject。 
 	/// </summary>
 	FallingFloor() {};
-	~FallingFloor() {};
+	~FallingFloor();
 
 
 	bool Start();

--- a/GameTemplate/Game/Game.cpp
+++ b/GameTemplate/Game/Game.cpp
@@ -85,7 +85,7 @@ namespace
 	const Vector3 TOWEL_SCALE(1.3f, 1.3f, 1.3f);
 	const Vector3 TOWEL_POSITION(-550.0f, 400.0f, 0.0f);
 	const Vector3 TOWELPOSITION(15100.0f, 1250.0f, 0.0f);
-	const Vector3 TOBE_WARE_OBJECT_POSITION(3800.0f, 350.0f, 0.0f);
+	const Vector3 TOBE_WARE_OBJECT_POSITION(3910.0f, 380.0f, 0.0f);
 	
 	const float TIMER = 180.0f;
 

--- a/GameTemplate/Game/Game.cpp
+++ b/GameTemplate/Game/Game.cpp
@@ -1138,9 +1138,6 @@ void Game::Stage1ObjectDelete()
 	//ドロップアイテムのクラスをここでFindGOしてからDeleteGOしてください。
 	m_mikan = FindGO<Mikan>("mikan");
 	DeleteGO(m_mikan);
-
-	//コリジョンオブジェクト
-	DeleteGOs("collisionobject");
 }
 
 //ステージ2オブジェクトの削除。
@@ -1173,9 +1170,6 @@ void Game::Stage2ObjectDelete()
 	DeleteGOs("towel");
 	m_taruto = FindGO<Taruto>("taruto");
 	DeleteGOs("taruto");
-
-	//コリジョンオブジェクト
-	DeleteGOs("collisionobject");
 }
 
 // マップをセットする。

--- a/GameTemplate/Game/MovingFloor.cpp
+++ b/GameTemplate/Game/MovingFloor.cpp
@@ -13,6 +13,10 @@ namespace
 	const Vector3 COLLISION_SIZE(365.0f, 5.0f, 225.0f);// コリジョンの大きさ。
 }
 
+MovingFloor::~MovingFloor()
+{
+	DeleteGO(m_collisionObject);
+}
 
 bool MovingFloor::Start()
 {

--- a/GameTemplate/Game/MovingFloor.h
+++ b/GameTemplate/Game/MovingFloor.h
@@ -12,7 +12,7 @@ public:
     /// </summary>
 
 	MovingFloor() {};
-	~MovingFloor() {};
+	~MovingFloor();
 
 	bool Start() override;
 	void Update()override; // 更新作業。

--- a/GameTemplate/Game/MovingNeedle.cpp
+++ b/GameTemplate/Game/MovingNeedle.cpp
@@ -19,7 +19,7 @@ MovingNeedle::MovingNeedle()
 }
 MovingNeedle::~MovingNeedle()
 {
-
+	DeleteGO(m_collisionObject);
 }
 bool MovingNeedle::Start()
 {

--- a/GameTemplate/Game/RotationFloor.cpp
+++ b/GameTemplate/Game/RotationFloor.cpp
@@ -11,6 +11,11 @@ namespace
 
 }
 
+RotationFloor::~RotationFloor()
+{
+	DeleteGO(m_collisionObject);
+}
+
 bool RotationFloor::Start()
 {
 	m_modelRender.Init("Assets/modelData/RotationFloor/RotationFloor.tkm", 0, 0, enModelUpAxisZ, false, true);

--- a/GameTemplate/Game/RotationFloor.h
+++ b/GameTemplate/Game/RotationFloor.h
@@ -5,7 +5,7 @@ class RotationFloor : public IGameObject
 {
 public:
 	RotationFloor() {};
-	~RotationFloor() {};
+	~RotationFloor();
 
 	bool Start();
 	void Update();

--- a/GameTemplate/Game/S_MovingFloor.cpp
+++ b/GameTemplate/Game/S_MovingFloor.cpp
@@ -14,6 +14,11 @@ namespace
 	const Vector3 COLLISION_SIZE(365.0f, 5.0f, 225.0f);// コリジョンの大きさ。
 }
 
+S_MovingFloor::~S_MovingFloor()
+{
+	DeleteGO(m_collisionObject);
+}
+
 bool S_MovingFloor::Start()
 {
 

--- a/GameTemplate/Game/S_MovingFloor.h
+++ b/GameTemplate/Game/S_MovingFloor.h
@@ -12,7 +12,7 @@ public:
     /// </summary>
 
 	S_MovingFloor() {};
-	~S_MovingFloor() {};
+	~S_MovingFloor();
 
 	bool Start() override;
 	void Update()override;// 更新作業。

--- a/GameTemplate/Game/Scaffold.cpp
+++ b/GameTemplate/Game/Scaffold.cpp
@@ -9,6 +9,10 @@ namespace
     const Vector3 COLLISION_SIZE(500.0f, 3.0f, 225.0f);// コリジョンの大きさ。
 }
 
+Scaffold::~Scaffold()
+{
+	DeleteGO(m_collisionObject);
+}
 
 bool Scaffold::Start()
 {

--- a/GameTemplate/Game/Scaffold.h
+++ b/GameTemplate/Game/Scaffold.h
@@ -9,7 +9,7 @@ public:
 	/// 看板。
 	/// </summary>
 	Scaffold() {};
-	~Scaffold() {};
+	~Scaffold();
 
 	bool Start();
 	void Update();// 更新作業。

--- a/GameTemplate/Game/ScaffoldBlock.cpp
+++ b/GameTemplate/Game/ScaffoldBlock.cpp
@@ -8,6 +8,12 @@ namespace
 	const Vector3 COLLISION_HEIGHT(0.0f, 250.0f, 0.0f);// コリジョンの高さ。
 	const Vector3 COLLISION_SIZE(500.0f, 3.0f, 225.0f);// コリジョンの大きさ。
 }
+
+ScaffoldBlock::~ScaffoldBlock()
+{
+	DeleteGO(m_collisionObject);
+}
+
 bool ScaffoldBlock::Start()
 {
 	string modelPath = m_config-> GetFullPath_3DModel("kinoko_ashiba_block");// ファイルパスを読み込む。

--- a/GameTemplate/Game/ScaffoldBlock.h
+++ b/GameTemplate/Game/ScaffoldBlock.h
@@ -10,7 +10,7 @@ public:
 	/// 足場ブロック。
 	/// </summary>
 	ScaffoldBlock() {};
-	~ScaffoldBlock() {};
+	~ScaffoldBlock();
 
 	bool Start();
 	void Update();// 更新作業。

--- a/GameTemplate/Game/StageClear.cpp
+++ b/GameTemplate/Game/StageClear.cpp
@@ -175,6 +175,7 @@ void StageClear::SetStageClearSpriteEasing()
 	m_beforeEasingPosition = m_position;
 	m_afterEasingPosition = STAGE2_AFTER_EASING;
 	m_easingTime = 0.0f;
+	g_gameTime->StopWatch(0.0f);
 }
 
 //ステージクリアスプライト用のイージングの更新処理。

--- a/GameTemplate/Game/StairsInTheForest.cpp
+++ b/GameTemplate/Game/StairsInTheForest.cpp
@@ -10,6 +10,11 @@ namespace
 
 }
 
+StairsInTheForest::~StairsInTheForest()
+{
+	DeleteGO(m_collisionObject);
+}
+
 // 初期化処理。
 bool StairsInTheForest::Start()
 {

--- a/GameTemplate/Game/StairsInTheForest.h
+++ b/GameTemplate/Game/StairsInTheForest.h
@@ -4,7 +4,7 @@ class StairsInTheForest : public IGameObject
 {
 public:
 	StairsInTheForest() {};
-	~StairsInTheForest() {};
+	~StairsInTheForest();
 
 	bool Start();// 初期化処理。
 	void Update();// 更新処理。

--- a/GameTemplate/Game/Tower.cpp
+++ b/GameTemplate/Game/Tower.cpp
@@ -14,6 +14,11 @@ namespace
 
 }
 
+Tower::~Tower()
+{
+	DeleteGO(m_collisionObject);
+}
+
 bool Tower::Start()
 {
 

--- a/GameTemplate/Game/Tower.h
+++ b/GameTemplate/Game/Tower.h
@@ -5,7 +5,7 @@ class Tower : public IGameObject
 {
 public:
 	Tower() {};
-	~Tower() {};
+	~Tower();
 
 	bool Start();// 初期化処理。
 	void Update();// 更新処理。

--- a/GameTemplate/Game/TransparentBlock.cpp
+++ b/GameTemplate/Game/TransparentBlock.cpp
@@ -73,12 +73,12 @@ void TransparentBlock::Update()
 	//透明ブロックを叩いていないとき。
 	if (m_blockTouchFlag != true)
 	{
+		//ブロックの表面のコリジョン衝突判定
+		BlockSurfaceCollisionHitDetection();
+
 		//X軸で一定の距離まで行っていたら。
 		if (m_blockTouchDistanceX.Length() < BLOCK_TOUCH_DISTANCE)
 		{
-			//ブロックの表面のコリジョン衝突判定
-			BlockSurfaceCollisionHitDetection();
-
 			//ブロックの表面のコリジョンが衝突していない状態で
 			//プレイヤーとブロックの底面のコリジョンが衝突したらプレイヤーが落下するかつモデルを不透明にする。
 			if (m_blockSurfaceCollisionHitFlag == false &&
@@ -152,15 +152,11 @@ void TransparentBlock::BlockSurfaceCollisionHitDetection()
 	//プレイヤーがジャンプしているとき
 	if (!m_player->m_characterController.IsOnGround())
 	{
-		//ブロックの表面のコリジョンに衝突していないとき
-		if (m_blockSurfaceCollisionHitFlag != true)
+		//プレイヤーがジャンプしているときにブロックの表面のコリジョンが衝突したら
+		if (m_blockSurfaceCollision->IsHit(m_player->GetCharacterController()) == true)
 		{
-			//プレイヤーがジャンプしているときにブロックの表面のコリジョンが衝突したら
-			if (m_blockSurfaceCollision->IsHit(m_player->GetCharacterController()) == true)
-			{
-				//ブロックの表面のコリジョンに衝突した
-				m_blockSurfaceCollisionHitFlag = true;
-			}
+			//ブロックの表面のコリジョンに衝突した
+			m_blockSurfaceCollisionHitFlag = true;
 		}
 	}
 	else

--- a/GameTemplate/Game/TransparentBlock.cpp
+++ b/GameTemplate/Game/TransparentBlock.cpp
@@ -22,6 +22,12 @@ namespace
 	const float ALPHA = 1.0f;
 }
 
+TransparentBlock::~TransparentBlock()
+{
+	DeleteGO(m_blockSurfaceCollision);
+	DeleteGO(m_blockBottomCollision);
+}
+
 //開始処理。
 bool TransparentBlock::Start()
 {

--- a/GameTemplate/Game/TransparentBlock.h
+++ b/GameTemplate/Game/TransparentBlock.h
@@ -9,6 +9,7 @@ class Config;
 class TransparentBlock : public IGameObject
 {
 public:
+	~TransparentBlock(); //デストラクタ
 	bool Start();  //開始処理。
 	void Update(); //更新処理。
 	void Render(RenderContext& rc);  //描画処理。


### PR DESCRIPTION
・砥部焼の配置位置の調整をしました。

・アイテムを取得した時にステージをクリアしたら演出が流れない不具合の修正をしました。

・ジャンプした時に透明ブロックの表面のコリジョンを触れた後ですぐにジャンプしたらブロックを叩いた判定にならない不具合の修正をしました。

・コリジョンオブジェクトがDeleteGOできていない不具合を修正しました。